### PR TITLE
Change Dockerfile to avoid sh wrapping

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,4 +17,4 @@ LABEL Description="New Relic Linux Server Monitor" vendor="New Relic Inc."
 
 ADD nrsysmond.x64 /usr/sbin/nrsysmond
 
-CMD /usr/sbin/nrsysmond -E -F
+CMD ["/usr/sbin/nrsysmond", "-E", "-F"]


### PR DESCRIPTION
The way Dockerfile is defined, docker will always wrap the command in a sh making all signals being ignored and making `docker stop` to fail.
With this, it should be fixed and nrsysmond should be able to catch the signal and react to `docker stop`.